### PR TITLE
Added SeisCon copy function

### DIFF
--- a/src/types/BlockScan.jl
+++ b/src/types/BlockScan.jl
@@ -1,3 +1,5 @@
+import Base.copy
+
 export BlockScan
 
 mutable struct BlockScan
@@ -7,3 +9,9 @@ mutable struct BlockScan
     summary::Dict{String, Array{Int32, 1}}
 end
 
+"""
+    copy(b::BlockScan)
+
+Create a copy of SeisCon object.
+"""
+copy(b::BlockScan) = BlockScan(b.file, b.startbyte, b.endbyte, b.summary)

--- a/src/types/BlockScan.jl
+++ b/src/types/BlockScan.jl
@@ -12,6 +12,6 @@ end
 """
     copy(b::BlockScan)
 
-Create a copy of SeisCon object.
+Create a copy of BlockScan object.
 """
 copy(b::BlockScan) = BlockScan(b.file, b.startbyte, b.endbyte, b.summary)

--- a/src/types/BlockScan.jl
+++ b/src/types/BlockScan.jl
@@ -9,9 +9,4 @@ mutable struct BlockScan
     summary::Dict{String, Array{Int32, 1}}
 end
 
-"""
-    copy(b::BlockScan)
-
-Create a copy of BlockScan object.
-"""
 copy(b::BlockScan) = BlockScan(b.file, b.startbyte, b.endbyte, b.summary)

--- a/src/types/SeisCon.jl
+++ b/src/types/SeisCon.jl
@@ -1,7 +1,7 @@
 # SeisCon type definition and methods
 import Base.size, Base.length, Base.getindex, Base.show
 
-export SeisCon, size, getindex, merge_con, split_con, show
+export SeisCon, size, getindex, copy, merge_con, split_con, show
 
 struct SeisCon
     ns::Int
@@ -19,6 +19,13 @@ end
 function getindex(con::SeisCon, a::Colon) 
     read_con(con, 1:length(con))
 end
+
+"""
+    copy(s::SeisCon)
+
+Create a copy of SeisCon object.
+"""
+copy(s::SeisCon) = SeisCon(s.ns, s.dsf, s.blocks)
 
 #=
 function show(s::SeisCon)

--- a/src/types/SeisCon.jl
+++ b/src/types/SeisCon.jl
@@ -20,11 +20,6 @@ function getindex(con::SeisCon, a::Colon)
     read_con(con, 1:length(con))
 end
 
-"""
-    copy(s::SeisCon)
-
-Create a copy of SeisCon object.
-"""
 copy(s::SeisCon) = SeisCon(s.ns, s.dsf, copy.(s.blocks))
 
 #=

--- a/src/types/SeisCon.jl
+++ b/src/types/SeisCon.jl
@@ -1,7 +1,7 @@
 # SeisCon type definition and methods
-import Base.size, Base.length, Base.getindex, Base.show
+import Base.size, Base.length, Base.getindex, Base.show, Base.copy
 
-export SeisCon, size, getindex, copy, merge_con, split_con, show
+export SeisCon, size, getindex, merge_con, split_con, show
 
 struct SeisCon
     ns::Int
@@ -25,7 +25,7 @@ end
 
 Create a copy of SeisCon object.
 """
-copy(s::SeisCon) = SeisCon(s.ns, s.dsf, s.blocks)
+copy(s::SeisCon) = SeisCon(s.ns, s.dsf, copy.(s.blocks))
 
 #=
 function show(s::SeisCon)


### PR DESCRIPTION
This function is required by JUDI's judiVector:
https://github.com/slimgroup/JUDI.jl/blob/16aa54abc9e1a18d8bd59636895afbd90718b0b7/src/TimeModeling/Types/judiVector.jl#L156

This is going to solve the issue: https://github.com/slimgroup/JUDI.jl/pull/181#issuecomment-1514766230

Nevertheless it is not possible to use this function as `copy(con)` because of the following warning:
```
WARNING: both SegyIO and Base export "copy"; uses of it in module Main must be qualified
```

It should be used as `SegyIO.copy(con)`.
Most likely JUDI's judiVector should be edited in appropriate way.